### PR TITLE
Potential fix for code scanning alert no. 1: Use of a known vulnerable action.

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Download source code artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: source-code
 
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Download source code artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: source-code
 
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Download Lambda Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: lambda-zip
 


### PR DESCRIPTION
Potential fix for [https://github.com/StreamForge-FiapX/lambda-uploaded-video-app/security/code-scanning/1](https://github.com/StreamForge-FiapX/lambda-uploaded-video-app/security/code-scanning/1)

To fix the problem, we need to update the `actions/download-artifact` action to version 4.1.7 in the `.github/workflows/ci-cd-pipeline.yml` file. This involves changing the version number in the `uses` field for each instance of the `actions/download-artifact` action.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
